### PR TITLE
Fix #3

### DIFF
--- a/lib/Twig/NodeVisitor/WhitespaceCollapser.php
+++ b/lib/Twig/NodeVisitor/WhitespaceCollapser.php
@@ -66,8 +66,8 @@ class WhitespaceCollapser extends \Twig_BaseNodeVisitor
             $node->setAttribute(
                 'data',
                 preg_replace(
-                    array('/\s{2,}/', '/<\s/', '/\s>/'),
-                    array(' ', '<', '>'),
+                    array('/\s</', '/>\s/', '/<\s/', '/\s>/'),
+                    array('<', '>', '<', '>'),
                     $text
                 )
             );


### PR DESCRIPTION
Proposition pour fixer l'issue 3

Au lieu de remplacer tout les espaces par un seul espace simple.

Je propose de supprimer tout les espaces avant une balise ouvrante ou fermante.

De cette façon on ne supprime pas les retours à la lignes à l'intérieur des balises.